### PR TITLE
Fix new topic label in whatsnew.yml template

### DIFF
--- a/.whatsnew.yml
+++ b/.whatsnew.yml
@@ -7,7 +7,7 @@ repos:
 
 # Labels for filtering
 labels:
-  - New doc
+  - New topic
   - Major update
   - Technical
 


### PR DESCRIPTION
Change `New doc` to `New topic` to match the label in the DevDocs repo.