### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    whatsup_github (0.1.0)
+    whatsup_github (0.1.1)
       netrc (~> 0.10)
       octokit (~> 4.14)
       thor (~> 0.20)

--- a/lib/whatsup_github/version.rb
+++ b/lib/whatsup_github/version.rb
@@ -1,3 +1,3 @@
 module WhatsupGithub
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
The 0.1.0 was yanked and cannot be re-pushed to rubygems remote